### PR TITLE
[codex] Bump Fastify to 5.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "btc-codex-trader",
+  "name": "btc-codex-trading-lab",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "btc-codex-trader",
+      "name": "btc-codex-trading-lab",
       "version": "0.1.0",
       "dependencies": {
         "@openai/codex-sdk": "^0.118.0",
         "dotenv": "^16.4.7",
-        "fastify": "^5.2.1",
+        "fastify": "^5.8.5",
         "ioredis": "^5.4.2",
         "pg": "^8.13.3",
         "pino": "^9.6.0",
@@ -1668,9 +1668,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.8.4",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
-      "integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@openai/codex-sdk": "^0.118.0",
     "dotenv": "^16.4.7",
-    "fastify": "^5.2.1",
+    "fastify": "^5.8.5",
     "ioredis": "^5.4.2",
     "pg": "^8.13.3",
     "pino": "^9.6.0",


### PR DESCRIPTION
## Summary
- bump `fastify` from the vulnerable `5.8.4` lockfile resolution to `5.8.5`
- raise the declared minimum Fastify version in `package.json` to the patched release
- refresh `package-lock.json` so clean installs resolve the fixed package

## Why
`npm audit` reported GHSA-247c-9743-5963 against `fastify@5.8.4` for a body schema validation bypass via a leading space in the `Content-Type` header. The repository built and tested cleanly before the change, so this is a narrow dependency maintenance fix with low blast radius.

## Validation
- `npm audit --json`
- `npm run build`
- `npm test`
