### PR TITLE
[codex] Fix doctor codex and redis probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Runtime flow:
 1. Copy `.env.example` to `.env`
 2. Fill the required credentials
 3. Authenticate Codex:
-   - `npx @openai/codex login --device-auth`
+   - `codex login --device-auth`
+   - If the `codex` binary is not installed yet: `npx @openai/codex login --device-auth`
 4. Install dependencies:
    - `npm install`
 5. Start local infrastructure:

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,5 +10,6 @@ fi
 
 npm install
 docker compose up -d postgres redis
-echo "Run 'npx @openai/codex login --device-auth' if Codex is not authenticated yet."
+echo "Run 'codex login --device-auth' if Codex is not authenticated yet."
+echo "If the codex binary is not installed yet, use 'npx @openai/codex login --device-auth'."
 echo "Then start paper trading with: npm run dev"

--- a/src/scripts/doctor.ts
+++ b/src/scripts/doctor.ts
@@ -21,9 +21,40 @@ const run = async (command: string, args: string[]): Promise<{ code: number; std
     child.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
   });
 
+const runCodexStatus = async (): Promise<{ code: number; stdout: string; stderr: string }> => {
+  const commands: Array<{ command: string; args: string[] }> = [
+    { command: "codex", args: ["login", "status"] },
+    { command: "npx", args: ["@openai/codex", "login", "status"] }
+  ];
+
+  for (const candidate of commands) {
+    try {
+      const result = await run(candidate.command, candidate.args);
+      if (result.code === 0 || !result.stderr.includes("could not determine executable to run")) {
+        return result;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  return {
+    code: 1,
+    stdout: "",
+    stderr: "Codex CLI not found in PATH and npx fallback was unavailable"
+  };
+};
+
 const main = async (): Promise<void> => {
   const pg = new Client({ connectionString: config.postgresUrl });
-  const redis = new Redis(config.redisUrl);
+  const redis = new Redis(config.redisUrl, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+    retryStrategy: () => null
+  });
+  redis.on("error", () => undefined);
   let postgres = "down";
   let redisState = "down";
   let app = "down";
@@ -40,6 +71,7 @@ const main = async (): Promise<void> => {
   }
 
   try {
+    await redis.connect();
     redisState = (await redis.ping()) === "PONG" ? "ok" : "down";
   } catch {
     redisState = "down";
@@ -72,7 +104,7 @@ const main = async (): Promise<void> => {
     telegram_present: Boolean(config.telegram.botToken && config.telegram.chatId)
   };
 
-  const codexStatus = await run("npx", ["@openai/codex", "login", "status"]);
+  const codexStatus = await runCodexStatus();
   logger.info(
     {
       checks,


### PR DESCRIPTION
## What changed
- make `npm run doctor` probe Codex auth through the `codex` CLI first, with `npx @openai/codex` as a fallback
- switch the Redis health probe to lazy connect with a no-op error listener so a down Redis instance reports cleanly instead of spamming stack traces
- update the setup docs and bootstrap output to prefer `codex login --device-auth`, while keeping the `npx` fallback documented

## Why
`npm run doctor` was noisy on a normal machine without Redis running, and its Codex auth check could misreport because the spawned CLI path was brittle inside the npm script environment.

## Impact
Developers get a cleaner local health check and setup instructions that match the working CLI path.

## Validation
- `npm test`
- `npm run build`
- `npm run doctor`