### PR TITLE
[codex] Add Dependabot updates for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
## Summary
- add a repository-level Dependabot configuration for the npm lockfile and GitHub Actions workflows
- schedule weekly update PRs so dependency and workflow drift shows up in the public repo before it turns into urgent maintenance
- keep the change isolated from the existing Fastify security bump PR

## Why
Today’s inspection found a real dependency maintenance gap: `npm audit` on `main` still reports GHSA-247c-9743-5963 against Fastify, and the repo currently depends on manual attention to notice that kind of drift. This config gives the repo a low-risk maintenance path for both package and Actions updates.

## Validation
- `npm run build`
- `npm test`
- `npm audit --json`
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`
