### PR TITLE
[codex] Add production dependency audit to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,22 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  audit-prod:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit production dependencies
+        run: npm run audit:prod

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Useful commands:
 
 - `npm test`
 - `npm run build`
+- `npm run audit:prod`
 - `npm run doctor`
 - `npm run backtest`
 - `./scripts/bootstrap.sh`
@@ -123,6 +124,11 @@ GitHub Actions runs:
 - `npm ci`
 - `npm run build`
 - `npm test`
+- `npm run audit:prod`
+
+Use the same audit check locally before opening a PR when you touch runtime dependencies:
+
+- `npm run audit:prod`
 
 ## Important caveats
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "start": "node dist/index.js",
     "backtest": "tsx src/scripts/backtest.ts",
     "doctor": "tsx src/scripts/doctor.ts",
+    "audit:prod": "npm audit --omit=dev --audit-level=high",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary
- add a dedicated CI job that runs a production-only dependency audit on pull requests and `main`
- expose the same check as `npm run audit:prod` so contributors can reproduce the GitHub Actions result locally
- document the audit command in the README alongside the existing build and test workflow

## Why
Issue #2 tracks a real gap in the repo's verification surface: `main` currently builds and tests cleanly while `npm audit --omit=dev --audit-level=high` still reports GHSA-247c-9743-5963 against the Fastify lockfile resolution.

This PR makes that security signal visible in CI instead of relying on manual audits.

## Notes
- The new audit job is expected to fail until the vulnerable Fastify resolution is updated.
- That behavior is intentional and matches the acceptance criteria in #2.
- The existing Fastify bump in #1 is the natural follow-up to get the new audit job green.

## Validation
- `npm run build`
- `npm test`
- `npm run audit:prod` *(fails on current `main` because the Fastify advisory is still present, which is the issue this PR surfaces)*

Refs #2
