### PR TITLE
[codex] Add production dependency audit workflow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,29 @@
+name: Dependency Audit
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ GitHub Actions runs:
 - `npm ci`
 - `npm run build`
 - `npm test`
+- weekly and on-demand production dependency audits with `npm audit --omit=dev --audit-level=high`
 
 ## Important caveats
 


### PR DESCRIPTION
## Summary

- add a dedicated GitHub Actions workflow for weekly and manual production dependency audits
- document the new audit coverage in the README CI section

## Why

The main CI workflow currently only builds and tests the project. A local `npm audit --omit=dev --json` run found a high-severity Fastify advisory (GHSA-247c-9743-5963), which shows there is real production dependency risk worth tracking continuously without turning every push into a failing security gate.

## Impact

This makes production dependency risk visible on a schedule and on demand, while keeping the existing push/PR CI focused on build and test feedback.

## Validation

- `npm run build`
- `npm test`
- `npm audit --omit=dev --json` (confirms the current vulnerability that motivated the workflow)

Refs #2
