### PR TITLE
[codex] Respect configured Binance user stream host

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ Runtime flow:
 6. Start the app:
    - `npm run dev`
 
+When using Binance testnet, staging, or a proxy, override both
+`BINANCE_FUTURES_BASE_URL` and `BINANCE_FUTURES_WS_URL` so REST listen-key
+creation, combined market streams, and user data streams all target the same
+environment.
+
 Useful commands:
 
 - `npm test`

--- a/src/infra/binance/binanceFuturesClient.test.ts
+++ b/src/infra/binance/binanceFuturesClient.test.ts
@@ -1,0 +1,36 @@
+import type { Logger } from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+
+import { BinanceFuturesClient } from "./binanceFuturesClient.js";
+
+vi.mock("ws", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    on: vi.fn()
+  }))
+}));
+
+const logger = {
+  warn: vi.fn()
+} as unknown as Logger;
+
+const client = (wsBaseUrl: string): BinanceFuturesClient =>
+  new BinanceFuturesClient("https://fapi.binance.com", wsBaseUrl, "api-key", "api-secret", logger);
+
+describe("BinanceFuturesClient", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the configured WebSocket host for combined market streams", () => {
+    expect(client("wss://example.test/futures/stream").getCombinedMarketStreamUrl("BTCUSDT")).toBe(
+      "wss://example.test/futures/stream?streams=btcusdt@markPrice@1s/btcusdt@bookTicker/btcusdt@kline_1m"
+    );
+  });
+
+  it("uses the configured WebSocket host for user streams", () => {
+    client("wss://example.test/futures/stream").connectUserStream("listen-key", vi.fn());
+
+    expect(WebSocket).toHaveBeenCalledWith("wss://example.test/futures/ws/listen-key");
+  });
+});

--- a/src/infra/binance/binanceFuturesClient.ts
+++ b/src/infra/binance/binanceFuturesClient.ts
@@ -250,7 +250,7 @@ export class BinanceFuturesClient {
   }
 
   public connectUserStream(listenKey: string, onMessage: (event: unknown) => void): WebSocket {
-    const socket = new WebSocket(`wss://fstream.binance.com/ws/${listenKey}`);
+    const socket = new WebSocket(this.getUserStreamUrl(listenKey));
     socket.on("message", (payload) => {
       try {
         onMessage(JSON.parse(payload.toString()) as unknown);
@@ -259,6 +259,15 @@ export class BinanceFuturesClient {
       }
     });
     return socket;
+  }
+
+  private getUserStreamUrl(listenKey: string): string {
+    const url = new URL(this.wsBaseUrl);
+    const basePath = url.pathname.replace(/\/stream\/?$/, "");
+    url.pathname = `${basePath}/ws/${listenKey}`.replace(/\/{2,}/g, "/");
+    url.search = "";
+    url.hash = "";
+    return url.toString();
   }
 
   public async composeInitialMarketSnapshot(symbol: string, filters?: SymbolFilters): Promise<MarketSnapshot> {


### PR DESCRIPTION
## Summary
- derive Binance user data stream sockets from `BINANCE_FUTURES_WS_URL` instead of hardcoded production
- add unit coverage for configured market and user WebSocket hosts
- document overriding REST and WebSocket Binance endpoints together for testnet, staging, or proxy use

## Why
`connectUserStream()` used `wss://fstream.binance.com/ws/...` even when the app was configured with another WebSocket host, so private account/order events could silently connect to a different environment than market data.

Closes #9.

## Validation
- `npm run build`
- `npm test`