### PR TITLE
[codex] Release the decision-loop Redis lock atomically

### DIFF
--- a/src/infra/store/redisHotStore.test.ts
+++ b/src/infra/store/redisHotStore.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const redisMock = {
+  del: vi.fn(),
+  eval: vi.fn(),
+  get: vi.fn(),
+  quit: vi.fn(),
+  set: vi.fn()
+};
+
+vi.mock("ioredis", () => ({
+  Redis: vi.fn(() => redisMock)
+}));
+
+import { RedisHotStore } from "./redisHotStore.js";
+
+describe("RedisHotStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisMock.eval.mockResolvedValue(1);
+    redisMock.quit.mockResolvedValue("OK");
+    redisMock.set.mockResolvedValue("OK");
+  });
+
+  it("releases a lock with one atomic compare-and-delete script", async () => {
+    const logger = { warn: vi.fn() } as never;
+    const store = new RedisHotStore("redis://localhost:6379", logger);
+
+    await store.releaseLock("decision-loop", "token-123");
+
+    expect(redisMock.eval).toHaveBeenCalledTimes(1);
+    expect(redisMock.eval).toHaveBeenCalledWith(expect.stringContaining('redis.call("GET", KEYS[1])'), 1, "decision-loop", "token-123");
+    expect(redisMock.get).not.toHaveBeenCalled();
+    expect(redisMock.del).not.toHaveBeenCalled();
+  });
+});

--- a/src/infra/store/redisHotStore.ts
+++ b/src/infra/store/redisHotStore.ts
@@ -1,6 +1,13 @@
 import { Redis } from "ioredis";
 import type { Logger } from "pino";
 
+const RELEASE_LOCK_SCRIPT = `
+  if redis.call("GET", KEYS[1]) == ARGV[1] then
+    return redis.call("DEL", KEYS[1])
+  end
+  return 0
+`;
+
 export class RedisHotStore {
   private readonly redis: Redis;
 
@@ -28,10 +35,7 @@ export class RedisHotStore {
   }
 
   public async releaseLock(key: string, token: string): Promise<void> {
-    const current = await this.redis.get(key);
-    if (current === token) {
-      await this.redis.del(key);
-    }
+    await this.redis.eval(RELEASE_LOCK_SCRIPT, 1, key, token);
   }
 
   public async close(): Promise<void> {


### PR DESCRIPTION
## Summary
- replace the lock release `GET` + `DEL` sequence with a single Redis-side compare-and-delete script
- add a focused regression test for `RedisHotStore.releaseLock()` so the unlock path stays atomic

## Why
Issue #23 describes a race where an expired lock can be reacquired by another worker and then incorrectly deleted by the first worker during `finally`. The release path now runs server-side in one round trip instead of two client-side operations.

## Verification
- `npm test`
- `npm run build`

Closes #23
