### PR TITLE
[codex] Prevent overlapping ingestor polls

### DIFF
--- a/src/services/ingestorScheduling.test.ts
+++ b/src/services/ingestorScheduling.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NewsIngestor } from "./newsIngestor.js";
+import { OnchainIngestor } from "./onchainIngestor.js";
+
+const logger = {
+  warn: vi.fn()
+};
+
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve();
+};
+
+const createDeferred = (): {
+  promise: Promise<void>;
+  resolve: () => void;
+} => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+
+  return { promise, resolve };
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("ingestor scheduling", () => {
+  it("prevents overlapping news polls while a timer tick is still in flight", async () => {
+    vi.useFakeTimers();
+
+    const ingestor = new NewsIngestor(
+      { feeds: { news: [], macro: [] } } as never,
+      logger as never,
+      vi.fn()
+    );
+
+    const deferred = createDeferred();
+    let calls = 0;
+    const pollSpy = vi.spyOn(ingestor as never, "poll").mockImplementation(() => {
+      calls += 1;
+      if (calls === 2) {
+        return deferred.promise;
+      }
+      return Promise.resolve();
+    });
+
+    await ingestor.start();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(pollSpy).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(pollSpy).toHaveBeenCalledTimes(2);
+
+    deferred.resolve();
+    await flushMicrotasks();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(pollSpy).toHaveBeenCalledTimes(3);
+
+    ingestor.stop();
+  });
+
+  it("prevents overlapping on-chain polls while a timer tick is still in flight", async () => {
+    vi.useFakeTimers();
+
+    const ingestor = new OnchainIngestor(
+      { onchainBaseUrl: "https://example.test" } as never,
+      logger as never,
+      vi.fn()
+    );
+
+    const deferred = createDeferred();
+    let calls = 0;
+    const pollSpy = vi.spyOn(ingestor as never, "poll").mockImplementation(() => {
+      calls += 1;
+      if (calls === 2) {
+        return deferred.promise;
+      }
+      return Promise.resolve();
+    });
+
+    await ingestor.start();
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(pollSpy).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(pollSpy).toHaveBeenCalledTimes(2);
+
+    deferred.resolve();
+    await flushMicrotasks();
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(pollSpy).toHaveBeenCalledTimes(3);
+
+    ingestor.stop();
+  });
+});

--- a/src/services/newsIngestor.ts
+++ b/src/services/newsIngestor.ts
@@ -15,6 +15,7 @@ const BTC_KEYWORDS = ["bitcoin", "btc", "etf", "fomc", "cpi", "inflation", "fed"
 export class NewsIngestor {
   private readonly seen = new Set<string>();
   private timer: NodeJS.Timeout | null = null;
+  private pollPromise: Promise<void> | null = null;
 
   public constructor(
     private readonly config: AppConfig,
@@ -23,9 +24,9 @@ export class NewsIngestor {
   ) {}
 
   public async start(): Promise<void> {
-    await this.poll();
+    await this.runPoll();
     this.timer = setInterval(() => {
-      void this.poll();
+      void this.runPoll();
     }, 60_000);
   }
 
@@ -33,6 +34,21 @@ export class NewsIngestor {
     if (this.timer) {
       clearInterval(this.timer);
     }
+  }
+
+  private runPoll(): Promise<void> {
+    if (this.pollPromise) {
+      return this.pollPromise;
+    }
+
+    const pollPromise = this.poll().finally(() => {
+      if (this.pollPromise === pollPromise) {
+        this.pollPromise = null;
+      }
+    });
+
+    this.pollPromise = pollPromise;
+    return pollPromise;
   }
 
   private async poll(): Promise<void> {

--- a/src/services/onchainIngestor.ts
+++ b/src/services/onchainIngestor.ts
@@ -26,6 +26,7 @@ export class OnchainIngestor {
   private lastHeight: number | null = null;
   private lastHeightAt: number | null = null;
   private lastFees: number | null = null;
+  private pollPromise: Promise<void> | null = null;
 
   public constructor(
     private readonly config: AppConfig,
@@ -34,9 +35,9 @@ export class OnchainIngestor {
   ) {}
 
   public async start(): Promise<void> {
-    await this.poll();
+    await this.runPoll();
     this.timer = setInterval(() => {
-      void this.poll();
+      void this.runPoll();
     }, 5 * 60_000);
   }
 
@@ -44,6 +45,21 @@ export class OnchainIngestor {
     if (this.timer) {
       clearInterval(this.timer);
     }
+  }
+
+  private runPoll(): Promise<void> {
+    if (this.pollPromise) {
+      return this.pollPromise;
+    }
+
+    const pollPromise = this.poll().finally(() => {
+      if (this.pollPromise === pollPromise) {
+        this.pollPromise = null;
+      }
+    });
+
+    this.pollPromise = pollPromise;
+    return pollPromise;
   }
 
   private async poll(): Promise<void> {


### PR DESCRIPTION
## Summary
- prevent `NewsIngestor` and `OnchainIngestor` from starting a second timer-driven poll while the previous cycle is still running
- reuse the in-flight poll promise so scheduled ticks collapse into a single active cycle instead of overlapping detached work
- add regression tests that hold a poll open across multiple timer ticks and verify each ingestor only runs one active cycle at a time

Closes #24

## Verification
- `npm test`
- `npm run build`
