### PR TITLE
[codex] Restore EventDetector retries after failed dispatch

### DIFF
--- a/src/services/eventDetector.test.ts
+++ b/src/services/eventDetector.test.ts
@@ -78,4 +78,17 @@ describe("EventDetector", () => {
     expect(onTrigger).toHaveBeenCalledTimes(1);
     expect(onTrigger.mock.calls[0]?.[0].reason).toBe("open_interest_spike");
   });
+
+  it("allows an immediate retry when trigger dispatch fails", async () => {
+    const onTrigger = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("redis unavailable"))
+      .mockResolvedValueOnce();
+    const detector = new EventDetector(onTrigger);
+
+    await expect(detector.heartbeat()).rejects.toThrow("redis unavailable");
+    await detector.heartbeat();
+
+    expect(onTrigger).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/services/eventDetector.ts
+++ b/src/services/eventDetector.ts
@@ -82,7 +82,16 @@ export class EventDetector {
       return;
     }
 
-    this.lastTriggered.set(trigger.reason, Date.now());
-    await this.onTrigger(trigger);
+    const triggeredAt = Date.now();
+    this.lastTriggered.set(trigger.reason, triggeredAt);
+
+    try {
+      await this.onTrigger(trigger);
+    } catch (error) {
+      if (this.lastTriggered.get(trigger.reason) === triggeredAt) {
+        this.lastTriggered.delete(trigger.reason);
+      }
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- roll back the per-reason cooldown entry when `EventDetector` dispatch fails
- keep the existing in-flight debounce behavior for successful trigger delivery
- add a regression test proving the same trigger reason can retry immediately after a failed dispatch

## Why
Issue #31 describes a reliability gap where `EventDetector.emit()` records cooldown state before awaiting `onTrigger(trigger)`. If the downstream evaluation path rejects early, the detector still suppresses the next same-reason event for the full cooldown window even though no evaluation completed.

This change preserves the current single-flight debounce during the active dispatch, but deletes that cooldown entry on failure so the next event can retry immediately.

## Validation
- `npm test -- src/services/eventDetector.test.ts`
- `npm run build`
- `npm test`

Closes #31.