### PR TITLE
[codex] Retry EventDetector triggers after dispatch failures

### DIFF
--- a/src/services/eventDetector.test.ts
+++ b/src/services/eventDetector.test.ts
@@ -78,4 +78,26 @@ describe("EventDetector", () => {
     expect(onTrigger).toHaveBeenCalledTimes(1);
     expect(onTrigger.mock.calls[0]?.[0].reason).toBe("open_interest_spike");
   });
+
+  it("retries the same trigger immediately after onTrigger rejects", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+    try {
+      const onTrigger = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("redis unavailable"))
+        .mockResolvedValueOnce(undefined);
+      const detector = new EventDetector(onTrigger);
+
+      await expect(detector.heartbeat()).rejects.toThrow("redis unavailable");
+      await detector.heartbeat();
+
+      expect(onTrigger).toHaveBeenCalledTimes(2);
+      expect(onTrigger.mock.calls[0]?.[0].reason).toBe("minute_recheck");
+      expect(onTrigger.mock.calls[1]?.[0].reason).toBe("minute_recheck");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/services/eventDetector.ts
+++ b/src/services/eventDetector.ts
@@ -77,12 +77,24 @@ export class EventDetector {
 
   private async emit(trigger: EvaluationTrigger): Promise<void> {
     const cooldownMs = trigger.reason === "minute_recheck" ? 50_000 : 20_000;
-    const last = this.lastTriggered.get(trigger.reason) ?? 0;
-    if (Date.now() - last < cooldownMs) {
+    const previousLast = this.lastTriggered.get(trigger.reason);
+    const last = previousLast ?? 0;
+    const now = Date.now();
+    if (now - last < cooldownMs) {
       return;
     }
 
-    this.lastTriggered.set(trigger.reason, Date.now());
-    await this.onTrigger(trigger);
+    this.lastTriggered.set(trigger.reason, now);
+
+    try {
+      await this.onTrigger(trigger);
+    } catch (error) {
+      if (previousLast === undefined) {
+        this.lastTriggered.delete(trigger.reason);
+      } else {
+        this.lastTriggered.set(trigger.reason, previousLast);
+      }
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- roll back EventDetector cooldown state when `onTrigger` rejects
- keep the existing in-flight debounce behavior for successful dispatches
- add a regression test proving the same trigger can retry immediately after a failed dispatch

## Verification
- `npm test -- src/services/eventDetector.test.ts`
- `npm run build`
- `npm test`

Closes #31