### PR TITLE
[codex] Release paper broker margin after TP1

### DIFF
--- a/src/services/brokers.ts
+++ b/src/services/brokers.ts
@@ -127,7 +127,6 @@ export class PaperBroker implements Broker {
     const now = Date.now();
 
     this.account.walletBalance -= fee;
-    this.account.availableBalance = Math.max(0, this.account.walletBalance - (fillPrice * plan.quantity) / plan.leverage);
     this.account.openOrders = 2;
 
     this.position = {
@@ -198,6 +197,7 @@ export class PaperBroker implements Broker {
       updatedAt: now
     };
 
+    this.syncAvailableBalance();
     this.markToMarket(market.markPrice);
 
     return {
@@ -363,7 +363,6 @@ export class PaperBroker implements Broker {
         realizedPnl: cumulativeNet
       };
       this.account.openOrders = 0;
-      this.account.availableBalance = this.account.walletBalance;
     } else {
       this.position = {
         ...this.position,
@@ -375,12 +374,9 @@ export class PaperBroker implements Broker {
         netRealizedPnl: cumulativeNet,
         takeProfit: this.position.tp2 ?? this.position.takeProfit
       };
-      this.account.availableBalance = Math.max(
-        0,
-        this.account.walletBalance - (this.position.entryPrice * this.position.quantity) / this.position.leverage
-      );
     }
 
+    this.syncAvailableBalance();
     this.markToMarket(market.markPrice);
     this.syncActiveTrade(reason, closeQty, grossPnl, fee, netPnl, remainingQty, exitPrice, now);
 
@@ -508,6 +504,17 @@ export class PaperBroker implements Broker {
       return false;
     }
     return this.position.side === "long" ? markPrice >= this.position.tp1 : markPrice <= this.position.tp1;
+  }
+
+  private syncAvailableBalance(): void {
+    if (this.position.side === "flat" || this.position.quantity <= 0) {
+      this.account.availableBalance = this.account.walletBalance;
+      return;
+    }
+
+    const leverage = Math.max(1, this.position.leverage);
+    const marginRequirement = (this.position.entryPrice * this.position.quantity) / leverage;
+    this.account.availableBalance = Math.max(0, this.account.walletBalance - marginRequirement);
   }
 }
 

--- a/src/services/brokers.ts
+++ b/src/services/brokers.ts
@@ -375,6 +375,10 @@ export class PaperBroker implements Broker {
         netRealizedPnl: cumulativeNet,
         takeProfit: this.position.tp2 ?? this.position.takeProfit
       };
+      this.account.availableBalance = Math.max(
+        0,
+        this.account.walletBalance - (this.position.entryPrice * this.position.quantity) / this.position.leverage
+      );
     }
 
     this.markToMarket(market.markPrice);

--- a/src/services/paperBroker.test.ts
+++ b/src/services/paperBroker.test.ts
@@ -121,6 +121,7 @@ describe("PaperBroker", () => {
     const open = await broker.execute(plan, context());
     expect(open.accepted).toBe(true);
     expect(open.tradeRecord?.status).toBe("open");
+    const availableBalanceBeforeTp1 = open.accountState.availableBalance;
 
     await broker.onMarketSnapshot?.({
       ...context().market_snapshot,
@@ -136,6 +137,12 @@ describe("PaperBroker", () => {
     expect(partial?.accepted).toBe(true);
     expect(partial?.tradeRecord?.status).toBe("partial");
     expect(partial?.positionState.quantity).toBeCloseTo(0.01, 5);
+    expect(partial?.accountState.availableBalance).toBeGreaterThan(availableBalanceBeforeTp1);
+    expect(partial?.accountState.availableBalance).toBeCloseTo(
+      partial!.accountState.walletBalance -
+        (open.positionState.entryPrice * partial!.positionState.quantity) / open.positionState.leverage,
+      5
+    );
 
     await broker.onMarketSnapshot?.({
       ...context().market_snapshot,


### PR DESCRIPTION
## Summary
- recompute `availableBalance` after partial paper-broker reductions so freed margin is released immediately
- add a regression assertion covering the TP1 lifecycle in `PaperBroker`

## Root cause
`PaperBroker.closeOrReducePosition()` only restored `availableBalance` on a full close. The TP1 partial-reduce path updated quantity and realized PnL but left the original margin lock in place.

## Validation
- `npm test -- src/services/paperBroker.test.ts`
- `npm test`
- `npm run build`

Fixes #36.
