### PR TITLE
[codex] Release paper available balance after partial exits

### DIFF
--- a/src/services/brokers.ts
+++ b/src/services/brokers.ts
@@ -127,7 +127,6 @@ export class PaperBroker implements Broker {
     const now = Date.now();
 
     this.account.walletBalance -= fee;
-    this.account.availableBalance = Math.max(0, this.account.walletBalance - (fillPrice * plan.quantity) / plan.leverage);
     this.account.openOrders = 2;
 
     this.position = {
@@ -198,6 +197,7 @@ export class PaperBroker implements Broker {
       updatedAt: now
     };
 
+    this.syncAvailableBalance();
     this.markToMarket(market.markPrice);
 
     return {
@@ -363,7 +363,6 @@ export class PaperBroker implements Broker {
         realizedPnl: cumulativeNet
       };
       this.account.openOrders = 0;
-      this.account.availableBalance = this.account.walletBalance;
     } else {
       this.position = {
         ...this.position,
@@ -377,6 +376,7 @@ export class PaperBroker implements Broker {
       };
     }
 
+    this.syncAvailableBalance();
     this.markToMarket(market.markPrice);
     this.syncActiveTrade(reason, closeQty, grossPnl, fee, netPnl, remainingQty, exitPrice, now);
 
@@ -504,6 +504,17 @@ export class PaperBroker implements Broker {
       return false;
     }
     return this.position.side === "long" ? markPrice >= this.position.tp1 : markPrice <= this.position.tp1;
+  }
+
+  private syncAvailableBalance(): void {
+    if (this.position.side === "flat" || this.position.quantity <= 0) {
+      this.account.availableBalance = this.account.walletBalance;
+      return;
+    }
+
+    const leverage = Math.max(1, this.position.leverage);
+    const marginRequirement = (this.position.entryPrice * this.position.quantity) / leverage;
+    this.account.availableBalance = Math.max(0, this.account.walletBalance - marginRequirement);
   }
 }
 

--- a/src/services/paperBroker.test.ts
+++ b/src/services/paperBroker.test.ts
@@ -121,6 +121,7 @@ describe("PaperBroker", () => {
     const open = await broker.execute(plan, context());
     expect(open.accepted).toBe(true);
     expect(open.tradeRecord?.status).toBe("open");
+    const availableAfterOpen = open.accountState.availableBalance;
 
     await broker.onMarketSnapshot?.({
       ...context().market_snapshot,
@@ -136,6 +137,11 @@ describe("PaperBroker", () => {
     expect(partial?.accepted).toBe(true);
     expect(partial?.tradeRecord?.status).toBe("partial");
     expect(partial?.positionState.quantity).toBeCloseTo(0.01, 5);
+    expect(partial?.accountState.availableBalance).toBeGreaterThan(availableAfterOpen);
+    expect(partial?.accountState.availableBalance).toBeCloseTo(
+      partial!.accountState.walletBalance - (partial!.positionState.entryPrice * partial!.positionState.quantity) / plan.leverage,
+      5
+    );
 
     await broker.onMarketSnapshot?.({
       ...context().market_snapshot,


### PR DESCRIPTION
## Summary
- recompute paper available balance from the remaining margin requirement after any position size change
- reuse the same balance sync on open and close/reduce paths so full closes and partial TP flows stay consistent
- add a regression assertion covering TP1 partial-reduce behavior in PaperBroker

## Testing
- `npm test -- --run src/services/paperBroker.test.ts`
- `npm test`

Refs #36
