### PR TITLE
[codex] Validate backtest env config

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "./config.js";
+
+describe("parseConfig", () => {
+  it("defaults backtest initial balance to the paper starting balance", () => {
+    const config = parseConfig({
+      PAPER_STARTING_BALANCE: "25000",
+      BACKTEST_DAYS: "30"
+    });
+
+    expect(config.paperStartingBalance).toBe(25_000);
+    expect(config.backtest.days).toBe(30);
+    expect(config.backtest.initialBalance).toBe(25_000);
+  });
+
+  it("accepts explicit backtest overrides", () => {
+    const config = parseConfig({
+      BACKTEST_DAYS: "14",
+      BACKTEST_INITIAL_BALANCE: "12000"
+    });
+
+    expect(config.backtest.days).toBe(14);
+    expect(config.backtest.initialBalance).toBe(12_000);
+  });
+
+  it("rejects invalid backtest env values", () => {
+    expect(() => parseConfig({ BACKTEST_DAYS: "abc" })).toThrow();
+    expect(() => parseConfig({ BACKTEST_DAYS: "0" })).toThrow();
+    expect(() => parseConfig({ BACKTEST_INITIAL_BALANCE: "" })).toThrow();
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,10 @@ const csvToList = (raw: string): string[] =>
     .map((value) => value.trim())
     .filter(Boolean);
 
-const envSchema = z.object({
+const emptyStringToInvalidNumber = (value: unknown): unknown =>
+  typeof value === "string" && value.trim() === "" ? Number.NaN : value;
+
+export const envSchema = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
   APP_PORT: z.coerce.number().int().positive().default(3000),
   LOG_LEVEL: z.string().default("info"),
@@ -37,6 +40,8 @@ const envSchema = z.object({
   SLIPPAGE_BPS: z.coerce.number().nonnegative().default(3),
   TAKER_FEE_BPS: z.coerce.number().nonnegative().default(4),
   PAPER_STARTING_BALANCE: z.coerce.number().positive().default(10000),
+  BACKTEST_DAYS: z.preprocess(emptyStringToInvalidNumber, z.coerce.number().int().positive().default(90)),
+  BACKTEST_INITIAL_BALANCE: z.preprocess(emptyStringToInvalidNumber, z.coerce.number().positive().optional()),
   CODEX_DECISION_TIMEOUT_MS: z.coerce.number().int().positive().default(45_000),
   CODEX_DECISION_MODEL: z.string().default("gpt-5.1-codex"),
   CODEX_USE_CLI_FALLBACK: z
@@ -44,8 +49,6 @@ const envSchema = z.object({
     .optional()
     .transform((value) => value !== "false")
 });
-
-const parsed = envSchema.parse(process.env);
 
 export interface AppConfig {
   nodeEnv: string;
@@ -74,6 +77,10 @@ export interface AppConfig {
   slippageBps: number;
   takerFeeBps: number;
   paperStartingBalance: number;
+  backtest: {
+    days: number;
+    initialBalance: number;
+  };
   codex: {
     timeoutMs: number;
     model: string;
@@ -81,44 +88,55 @@ export interface AppConfig {
   };
 }
 
-export const config: AppConfig = {
-  nodeEnv: parsed.NODE_ENV,
-  port: parsed.APP_PORT,
-  logLevel: parsed.LOG_LEVEL,
-  tradingMode: parsed.TRADING_MODE,
-  symbol: parsed.SYMBOL.toUpperCase(),
-  binance: {
-    restBaseUrl: parsed.BINANCE_FUTURES_BASE_URL,
-    wsBaseUrl: parsed.BINANCE_FUTURES_WS_URL,
-    apiKey: parsed.BINANCE_API_KEY,
-    apiSecret: parsed.BINANCE_API_SECRET
-  },
-  postgresUrl: parsed.POSTGRES_URL,
-  redisUrl: parsed.REDIS_URL,
-  telegram: {
-    botToken: parsed.TELEGRAM_BOT_TOKEN || undefined,
-    chatId: parsed.TELEGRAM_CHAT_ID || undefined
-  },
-  feeds: {
-    news: csvToList(parsed.NEWS_FEEDS),
-    macro: csvToList(parsed.MACRO_FEEDS)
-  },
-  onchainBaseUrl: parsed.ONCHAIN_BASE_URL,
-  riskPolicy: {
-    maxLeverage: parsed.MAX_LEVERAGE,
-    riskPerTrade: parsed.RISK_PER_TRADE,
-    maxDailyLoss: parsed.MAX_DAILY_LOSS,
-    maxWeeklyDrawdown: parsed.MAX_WEEKLY_DRAWDOWN,
-    maxOpenPositions: parsed.MAX_OPEN_POSITIONS,
-    cooldownMinutes: parsed.COOLDOWN_MINUTES,
-    minRiskReward: parsed.MIN_RISK_REWARD
-  },
-  slippageBps: parsed.SLIPPAGE_BPS,
-  takerFeeBps: parsed.TAKER_FEE_BPS,
-  paperStartingBalance: parsed.PAPER_STARTING_BALANCE,
-  codex: {
-    timeoutMs: parsed.CODEX_DECISION_TIMEOUT_MS,
-    model: parsed.CODEX_DECISION_MODEL,
-    useCliFallback: parsed.CODEX_USE_CLI_FALLBACK
-  }
+export const parseConfig = (env: NodeJS.ProcessEnv = process.env): AppConfig => {
+  const parsed = envSchema.parse(env);
+  const paperStartingBalance = parsed.PAPER_STARTING_BALANCE;
+
+  return {
+    nodeEnv: parsed.NODE_ENV,
+    port: parsed.APP_PORT,
+    logLevel: parsed.LOG_LEVEL,
+    tradingMode: parsed.TRADING_MODE,
+    symbol: parsed.SYMBOL.toUpperCase(),
+    binance: {
+      restBaseUrl: parsed.BINANCE_FUTURES_BASE_URL,
+      wsBaseUrl: parsed.BINANCE_FUTURES_WS_URL,
+      apiKey: parsed.BINANCE_API_KEY,
+      apiSecret: parsed.BINANCE_API_SECRET
+    },
+    postgresUrl: parsed.POSTGRES_URL,
+    redisUrl: parsed.REDIS_URL,
+    telegram: {
+      botToken: parsed.TELEGRAM_BOT_TOKEN || undefined,
+      chatId: parsed.TELEGRAM_CHAT_ID || undefined
+    },
+    feeds: {
+      news: csvToList(parsed.NEWS_FEEDS),
+      macro: csvToList(parsed.MACRO_FEEDS)
+    },
+    onchainBaseUrl: parsed.ONCHAIN_BASE_URL,
+    riskPolicy: {
+      maxLeverage: parsed.MAX_LEVERAGE,
+      riskPerTrade: parsed.RISK_PER_TRADE,
+      maxDailyLoss: parsed.MAX_DAILY_LOSS,
+      maxWeeklyDrawdown: parsed.MAX_WEEKLY_DRAWDOWN,
+      maxOpenPositions: parsed.MAX_OPEN_POSITIONS,
+      cooldownMinutes: parsed.COOLDOWN_MINUTES,
+      minRiskReward: parsed.MIN_RISK_REWARD
+    },
+    slippageBps: parsed.SLIPPAGE_BPS,
+    takerFeeBps: parsed.TAKER_FEE_BPS,
+    paperStartingBalance,
+    backtest: {
+      days: parsed.BACKTEST_DAYS,
+      initialBalance: parsed.BACKTEST_INITIAL_BALANCE ?? paperStartingBalance
+    },
+    codex: {
+      timeoutMs: parsed.CODEX_DECISION_TIMEOUT_MS,
+      model: parsed.CODEX_DECISION_MODEL,
+      useCliFallback: parsed.CODEX_USE_CLI_FALLBACK
+    }
+  };
 };
+
+export const config = parseConfig();

--- a/src/scripts/backtest.ts
+++ b/src/scripts/backtest.ts
@@ -31,8 +31,9 @@ type Candle = {
   closeTime: number;
 };
 
-const days = Number(process.env.BACKTEST_DAYS ?? 90);
-const initialBalance = Number(process.env.BACKTEST_INITIAL_BALANCE ?? config.paperStartingBalance);
+const {
+  backtest: { days, initialBalance }
+} = config;
 
 const ema = (values: number[], period: number): number => {
   const k = 2 / (period + 1);


### PR DESCRIPTION
## Summary
- validate `BACKTEST_DAYS` and `BACKTEST_INITIAL_BALANCE` through the shared config surface
- preserve the backtest initial-balance fallback to `PAPER_STARTING_BALANCE` when no override is set
- add focused regression coverage for valid overrides and invalid env input

## Verification
- npm test
- npm run build

Refs #48