### PR TITLE
[codex] Normalize CLI fallback env parsing

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+const loadConfig = async () => {
+  vi.resetModules();
+  return import("./config.js");
+};
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.resetModules();
+});
+
+describe("config", () => {
+  it("defaults CODEX_USE_CLI_FALLBACK to true when unset", async () => {
+    delete process.env.CODEX_USE_CLI_FALLBACK;
+
+    const { config } = await loadConfig();
+
+    expect(config.codex.useCliFallback).toBe(true);
+  });
+
+  it("accepts common false-like values for CODEX_USE_CLI_FALLBACK", async () => {
+    for (const value of ["false", "FALSE", "0", "no", "off"]) {
+      process.env = {
+        ...ORIGINAL_ENV,
+        CODEX_USE_CLI_FALLBACK: value
+      };
+
+      const { config } = await loadConfig();
+      expect(config.codex.useCliFallback, `expected ${value} to disable fallback`).toBe(false);
+    }
+  });
+
+  it("trims and splits configured feed lists", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NEWS_FEEDS: " https://news.example/a.xml , ,https://news.example/b.xml ",
+      MACRO_FEEDS: " https://macro.example/feed "
+    };
+
+    const { config } = await loadConfig();
+
+    expect(config.feeds.news).toEqual([
+      "https://news.example/a.xml",
+      "https://news.example/b.xml"
+    ]);
+    expect(config.feeds.macro).toEqual(["https://macro.example/feed"]);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,27 @@ const csvToList = (raw: string): string[] =>
     .map((value) => value.trim())
     .filter(Boolean);
 
+const parseBooleanEnv = (raw: string | undefined, defaultValue: boolean): boolean => {
+  if (raw === undefined) {
+    return defaultValue;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "") {
+    return defaultValue;
+  }
+
+  if (["false", "0", "no", "off"].includes(normalized)) {
+    return false;
+  }
+
+  if (["true", "1", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+
+  return defaultValue;
+};
+
 const envSchema = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
   APP_PORT: z.coerce.number().int().positive().default(3000),
@@ -42,7 +63,7 @@ const envSchema = z.object({
   CODEX_USE_CLI_FALLBACK: z
     .string()
     .optional()
-    .transform((value) => value !== "false")
+    .transform((value) => parseBooleanEnv(value, true))
 });
 
 const parsed = envSchema.parse(process.env);


### PR DESCRIPTION
## Summary
- normalize `CODEX_USE_CLI_FALLBACK` parsing so common false-like values such as `FALSE`, `0`, `no`, and `off` disable the fallback consistently
- keep the default enabled behavior when the variable is unset or blank
- add config regression tests for the fallback toggle and feed-list parsing

## Why
`src/config.ts` previously treated every value except the exact lowercase string `false` as enabled. That made the fallback toggle fragile in real deployments because common shell or secrets-manager values like `FALSE` or `0` silently kept the CLI fallback on.

## Impact
This makes the Codex fallback flag behave predictably across local shells, CI, and deployment environments without changing the default paper-mode behavior.

## Validation
- `npm test`
- `npm run build`
